### PR TITLE
Fix JwtService parameter order

### DIFF
--- a/auth-service/src/main/java/com/yangyag/msa/auth/service/JwtService.java
+++ b/auth-service/src/main/java/com/yangyag/msa/auth/service/JwtService.java
@@ -4,7 +4,7 @@ import com.yangyag.msa.auth.model.entity.Role;
 import io.jsonwebtoken.Claims;
 
 public interface JwtService {
-    String generateToken(String username, String userId, Role userRole);
+    String generateToken(String userId, String username, Role userRole);
 
     boolean validateToken(String token);
 


### PR DESCRIPTION
## Summary
- fix wrong parameter order in `JwtService.generateToken`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6844773b79948323bece70f5d87c0678