### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@
 ##### - Factory Pattern
 ##### - CQRS Pattern 준수
 
-## 4. Kubernetis
-#### - minikukbe 에서 구동
+## 4. Kubernetes
+#### - minikube 에서 구동
 #### - .k8s 폴더의 k8s-manifests.yaml 참조
 #### - Front 영역은 Vue.js 로 구성 중
 


### PR DESCRIPTION
## Summary
- fix typos in README

## Testing
- `grep -n "Kubernetes" -n README.md`
- `grep -n "minikube" -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_684479469ff883238f21dfe24467f753